### PR TITLE
ci: add lint + typecheck workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: CI only needs to read the checked-out code. No write scopes,
+# and no Pinecone/OpenAI credentials are exposed here — any live/credentialed
+# checks must be gated separately (see the test-suite issue), never in PR CI.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint & typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # `npm install` rather than `npm ci`: package-lock.json is currently out
+      # of sync with package.json, so `npm ci` fails. Switch this to `npm ci`
+      # once the lockfile is regenerated (see the Dependabot/lockfile issue).
+      - run: npm install
+
+      - run: npm run lint
+
+      # `tsc --noEmit` is the real type check. This example runs from source via
+      # `tsx`, so there is no bundler build step to smoke-test here.
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsup",
     "index": "tsx -r dotenv/config src/index.ts",
     "chat": "tsx -r dotenv/config src/chat.ts",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "npm run lint --fix",
     "format": "prettier --write \"**/*.ts\"",

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { Pipeline, pipeline } from "@xenova/transformers";
+import { FeatureExtractionPipeline, pipeline } from "@xenova/transformers";
 import { Vector } from "@pinecone-database/pinecone";
 import { Document } from 'langchain/document';
 import { EmbeddingsParams, Embeddings } from "langchain/embeddings/base";
@@ -13,7 +13,7 @@ function isString(test: any): test is string {
 }
 
 class Embedder {
-  private pipe: Pipeline;
+  private pipe: FeatureExtractionPipeline;
 
   async init(modelName: string) {
     this.pipe = await pipeline(
@@ -65,7 +65,7 @@ interface TransformersJSEmbeddingParams extends EmbeddingsParams {
 class TransformersJSEmbedding extends Embeddings implements TransformersJSEmbeddingParams {
   modelName: string;
 
-  pipe: Pipeline | null = null;
+  pipe: FeatureExtractionPipeline | null = null;
 
   constructor(params: TransformersJSEmbeddingParams) {
     super(params);


### PR DESCRIPTION
## Problem

The repo has no CI — there is no `.github/workflows` directory, so nothing verifies lint or type-checking on push or PR. Every future change is unguarded, which is especially dangerous for the upcoming risky core-stack modernization (#16). That modernization needs a safety net to exist *first*, and this workflow (plus the test suite, #15) is that net.

While wiring this up I found the pre-modernization `main` could not actually satisfy the checks the audit assumed would be green:

- **`npm ci` fails** — `package-lock.json` is out of sync with `package.json`. Regenerating the lockfile is tracked separately (#17, which depends on #16), so it is out of scope here.
- **`tsc --noEmit` failed** on `src/embeddings.ts` — `@xenova/transformers` (now 2.17.x) changed its pipeline types.
- **`npm run build` (tsup) failed** — the code uses top-level `await` and an async generator, which the `es2017` build target can't compile.

## Solution

**Scope: lint + typecheck, no build step.** `tsup` is a *bundler* that produces a publishable `dist/` library artifact — but this is a runnable example executed straight from source via `tsx` (`npm run index` / `npm run chat`), never published, and #14 plans to remove that scaffolding entirely. Critically, esbuild/tsup strips types **without** checking them, so a green build proves nothing about type safety. The check that actually enforces types is `tsc --noEmit`, so CI runs that instead of a meaningless (and currently broken) bundler build.

**Least privilege.** `GITHUB_TOKEN` is scoped to `contents: read` at the top level — CI only reads the checked-out code. No Pinecone/OpenAI credentials are present; any live/credentialed checks must be gated separately (see #15), never in untrusted-PR CI.

**`npm install`, not `npm ci`.** `npm ci` requires a synced lockfile, which doesn't exist until #17 regenerates it. The workflow uses `npm install` with an inline comment to switch back to `npm ci` once the lockfile is fixed.

**Green on main.** Two source-adjacent fixes were needed so the job is green today:
- `src/embeddings.ts`: annotate the pipeline fields as `FeatureExtractionPipeline` (the actual return of `pipeline("embeddings", …)`) instead of the broad `Pipeline` type. This is the minimum needed; #16 will rewrite this file more thoroughly.
- Added a reusable `typecheck` npm script (`tsc --noEmit`) that #15/#16 can also use.

Verified locally: `npm run lint` and `npm run typecheck` both exit 0.

Closes #13
Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)