### PR TITLE
test: add vitest suite (unit + self-skipping live e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,18 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Allows the credentialed live e2e job below to be triggered manually.
+  workflow_dispatch:
 
-# Least privilege: CI only needs to read the checked-out code. No write scopes,
-# and no Pinecone/OpenAI credentials are exposed here — any live/credentialed
-# checks must be gated separately (see the test-suite issue), never in PR CI.
+# Least privilege: CI only needs to read the checked-out code. No write scopes.
+# Live Pinecone/OpenAI credentials are exposed only to the `e2e` job below, and
+# only off untrusted PRs — never to lint/typecheck/unit steps.
 permissions:
   contents: read
 
 jobs:
   build:
-    name: Lint & typecheck
+    name: Lint, typecheck & unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,3 +35,29 @@ jobs:
       # `tsc --noEmit` is the real type check. This example runs from source via
       # `tsx`, so there is no bundler build step to smoke-test here.
       - run: npm run typecheck
+
+      # Unit tests are credential-free and run on every push + PR.
+      - run: npm run test:unit
+
+  e2e:
+    name: Live e2e (Pinecone)
+    runs-on: ubuntu-latest
+    # Never run the credentialed live suite on untrusted pull requests — only on
+    # pushes to main and manual dispatch, where repo secrets are trusted. The
+    # test itself also self-skips when the secrets are absent.
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm install
+
+      - run: npm run test:e2e
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "index": "tsx -r dotenv/config src/index.ts",
     "chat": "tsx -r dotenv/config src/chat.ts",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run tests/unit",
+    "test:e2e": "vitest run tests/e2e",
     "lint": "eslint src",
     "lint:fix": "npm run lint --fix",
     "format": "prettier --write \"**/*.ts\"",
@@ -56,6 +59,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.3",
     "tsx": "^3.12.3",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "vitest": "^3.2.7"
   }
 }

--- a/tests/e2e/ingest-retrieve.test.ts
+++ b/tests/e2e/ingest-retrieve.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { PineconeClient, utils, type Vector } from "@pinecone-database/pinecone";
+import { embedder } from "../../src/embeddings.js";
+
+const { createIndexIfNotExists, chunkedUpsert, waitUntilIndexIsReady } = utils;
+
+// Live end-to-end test: exercises a real embed -> upsert -> query round-trip
+// against Pinecone. It is GATED and SELF-SKIPPING — with no credentials it
+// skips cleanly (so `npm test` is green locally and on untrusted-PR CI), and it
+// only runs on main / workflow_dispatch where secrets are available.
+//
+// It gates on PINECONE_API_KEY (+ PINECONE_ENVIRONMENT, required by the current
+// pod-based SDK). Ingestion + retrieval need only Pinecone and the local
+// transformers embedder — no OpenAI. When #16 modernizes the stack this file is
+// re-pointed at the serverless v8 API (dropping PINECONE_ENVIRONMENT), and an
+// agent-level e2e (which needs OPENAI_API_KEY) becomes possible once chat.ts is
+// importable. See issue #16.
+const apiKey = process.env.PINECONE_API_KEY;
+const environment = process.env.PINECONE_ENVIRONMENT;
+const hasCredentials = Boolean(apiKey && environment);
+
+// all-MiniLM-L6-v2 produces 384-dim vectors.
+const MODEL = "Xenova/all-MiniLM-L6-v2";
+const DIMENSION = 384;
+const NAMESPACE = "default";
+
+// A uniquely-named throwaway index so concurrent runs never collide and cleanup
+// can never clobber a real index. Index names are lowercase alphanumeric+hyphen.
+const indexName = `e2e-ingest-retrieve-${Date.now().toString(36)}`;
+
+describe.skipIf(!hasCredentials)("live ingestion + retrieval", () => {
+  const client = new PineconeClient();
+
+  afterAll(async () => {
+    // Tear down the throwaway index even if an assertion failed mid-test.
+    try {
+      await client.deleteIndex({ indexName });
+    } catch (error) {
+      console.error(`Failed to delete test index ${indexName}:`, error);
+    }
+  });
+
+  it("upserts embedded documents and retrieves the most relevant one", async () => {
+    await client.init({ apiKey: apiKey!, environment: environment! });
+
+    // Distinct facts so retrieval has an unambiguous best match to return.
+    const documents = [
+      { id: "sky", text: "The sky appears blue because of Rayleigh scattering." },
+      { id: "grass", text: "Grass is green because it contains chlorophyll." },
+      { id: "sun", text: "The sun is a star at the center of the solar system." },
+    ];
+
+    await client.createIndex({
+      createRequest: { name: indexName, dimension: DIMENSION, metric: "cosine" },
+    });
+    // Poll for readiness rather than sleeping a fixed interval — index creation
+    // latency is variable.
+    await waitUntilIndexIsReady(client, indexName);
+    await createIndexIfNotExists(client, indexName, DIMENSION);
+
+    const index = client.Index(indexName);
+
+    await embedder.init(MODEL);
+    const vectors: Vector[] = [];
+    await embedder.embedBatch(
+      documents.map((d) => d.text),
+      documents.length,
+      (embeddings) => {
+        // Re-key each vector by its stable document id so we can assert which
+        // one comes back (embedBatch assigns random UUIDs to bare strings).
+        embeddings.forEach((v, i) => {
+          v.id = documents[i].id;
+          v.metadata = { text: documents[i].text };
+        });
+        vectors.push(...embeddings);
+      },
+    );
+
+    await chunkedUpsert(index, vectors, NAMESPACE);
+
+    // Upserts are eventually consistent — poll describeIndexStats with backoff
+    // until all vectors are visible, instead of a single fixed sleep.
+    await waitForVectorCount(index, documents.length);
+
+    const [queryVector] = (
+      await embedQuery("Why does the sky look blue during the day?")
+    );
+    const result = await index.query({
+      queryRequest: {
+        vector: queryVector,
+        topK: 1,
+        namespace: NAMESPACE,
+        includeMetadata: true,
+      },
+    });
+
+    expect(result.matches?.[0]?.id).toBe("sky");
+  });
+
+  // Embed a single query string to a raw vector for querying.
+  async function embedQuery(text: string): Promise<number[][]> {
+    const out: number[][] = [];
+    await embedder.embedBatch([text], 1, (embeddings) => {
+      out.push(embeddings[0].values);
+    });
+    return out;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function waitForVectorCount(index: any, expected: number): Promise<void> {
+    const maxAttempts = 20;
+    let delayMs = 1000;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const stats = await index.describeIndexStats({ describeIndexStatsRequest: {} });
+      const count = stats.namespaces?.[NAMESPACE]?.vectorCount ?? 0;
+      if (count >= expected) return;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, 8000); // exponential backoff, capped
+    }
+    throw new Error(
+      `Only ${expected} vectors expected but never became visible in index ${indexName}`,
+    );
+  }
+});

--- a/tests/unit/dataLoader.test.ts
+++ b/tests/unit/dataLoader.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as dfd from "danfojs-node";
+import { dropDuplicates } from "../../src/utils/dataLoader.js";
+
+describe("dropDuplicates", () => {
+  it("removes rows whose values in the target column are duplicated", () => {
+    const df = new dfd.DataFrame({
+      context: ["alpha", "alpha", "beta", "gamma"],
+      id: ["1", "2", "3", "4"],
+    });
+
+    const result = dropDuplicates(df, "context");
+
+    // "alpha" appears twice; only its first occurrence survives.
+    expect(result.shape[0]).toBe(3);
+    expect(result["context"].values).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("is a no-op (by row count) when the target column has no duplicates", () => {
+    const df = new dfd.DataFrame({
+      context: ["one", "two", "three"],
+      id: ["1", "2", "3"],
+    });
+
+    const result = dropDuplicates(df, "context");
+
+    expect(result.shape[0]).toBe(3);
+    expect(result["context"].values).toEqual(["one", "two", "three"]);
+  });
+});

--- a/tests/unit/embeddings.test.ts
+++ b/tests/unit/embeddings.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Vector } from "@pinecone-database/pinecone";
+
+// Mock the transformers pipeline so the batching logic can be tested offline,
+// without downloading a model or running inference. The mock returns a fixed
+// 3-dim embedding regardless of input.
+const MOCK_EMBEDDING = [0.1, 0.2, 0.3];
+vi.mock("@xenova/transformers", () => ({
+  pipeline: vi.fn(async () => async (_text: string) => ({
+    data: Float32Array.from(MOCK_EMBEDDING),
+  })),
+}));
+
+// Imported after the mock is registered.
+const { embedder } = await import("../../src/embeddings.js");
+const { Document } = await import("langchain/document");
+
+describe("Embedder.embedBatch", () => {
+  beforeEach(async () => {
+    await embedder.init("mock-model");
+  });
+
+  it("splits documents into batches of the requested size", async () => {
+    const documents = ["a", "b", "c", "d", "e"];
+    const batches: Vector[][] = [];
+
+    await embedder.embedBatch(documents, 2, (embeddings) => {
+      batches.push(embeddings);
+    });
+
+    // 5 documents, batch size 2 -> [2, 2, 1]
+    expect(batches.map((b) => b.length)).toEqual([2, 2, 1]);
+  });
+
+  it("produces one embedding per document with the model's vector values", async () => {
+    const documents = ["only-one"];
+    const collected: Vector[] = [];
+
+    await embedder.embedBatch(documents, 5, (embeddings) => {
+      collected.push(...embeddings);
+    });
+
+    expect(collected).toHaveLength(1);
+    // Values round-trip through a Float32Array, so compare with tolerance
+    // rather than for exact float equality.
+    expect(collected[0].values).toHaveLength(MOCK_EMBEDDING.length);
+    collected[0].values.forEach((v, i) => expect(v).toBeCloseTo(MOCK_EMBEDDING[i], 5));
+    // A string document with no metadata falls back to storing its own text.
+    expect(collected[0].metadata).toEqual({ text: "only-one" });
+    expect(typeof collected[0].id).toBe("string");
+  });
+
+  it("preserves document metadata and uses its id when embedding Documents", async () => {
+    const documents = [
+      new Document({ pageContent: "context text", metadata: { id: "doc-42" } }),
+    ];
+    const collected: Vector[] = [];
+
+    await embedder.embedBatch(documents, 1, (embeddings) => {
+      collected.push(...embeddings);
+    });
+
+    expect(collected[0].id).toBe("doc-42");
+    expect(collected[0].metadata).toEqual({ id: "doc-42" });
+  });
+});

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { sliceIntoChunks, getEnv } from "../../src/utils/util.js";
+
+describe("sliceIntoChunks", () => {
+  it("splits an array evenly when the length is a multiple of the chunk size", () => {
+    expect(sliceIntoChunks([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("leaves a smaller final chunk when the length is not a multiple", () => {
+    expect(sliceIntoChunks([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns a single chunk when the chunk size exceeds the array length", () => {
+    expect(sliceIntoChunks([1, 2], 10)).toEqual([[1, 2]]);
+  });
+
+  it("returns no chunks for an empty array", () => {
+    expect(sliceIntoChunks([], 3)).toEqual([]);
+  });
+});
+
+describe("getEnv", () => {
+  const KEY = "UTIL_TEST_ENV_VAR";
+
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("returns the value when the variable is set", () => {
+    process.env[KEY] = "hello";
+    expect(getEnv(KEY)).toBe("hello");
+  });
+
+  it("throws a descriptive error when the variable is missing", () => {
+    expect(() => getEnv(KEY)).toThrowError(
+      `${KEY} environment variable not set`,
+    );
+  });
+
+  it("throws when the variable is set to an empty string", () => {
+    process.env[KEY] = "";
+    expect(() => getEnv(KEY)).toThrowError(
+      `${KEY} environment variable not set`,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Node environment: this project talks to Pinecone/OpenAI and uses
+    // danfojs-node + onnxruntime, none of which belong in a browser env.
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    // The live e2e waits on Pinecone index creation + eventual consistency,
+    // so it needs a generous ceiling. Unit tests finish well under this.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Problem

The repo had no automated tests. The next queued item — the core-stack modernization (#16, a wide rewrite of ingestion + the agent across removed Pinecone v0.1 and LangChain 0.0.x APIs) — is **risky** and, per the maintenance sweep's ordering, must not land before a verification safety net exists. Nothing currently proves the pure logic keeps working across that rewrite, and there's no harness to exercise a real ingestion → retrieval round-trip.

## Solution

Adds **Vitest** and builds the two test layers that fit this example, structured so the suite is green today and gives #16 something to break against:

- **Unit tests (credential-free)** cover the pure logic that survives the modernization conceptually, so a regression in #16 surfaces immediately:
  - `sliceIntoChunks` / `getEnv` (`src/utils/util.ts`)
  - `Embedder.embedBatch` batching (`src/embeddings.ts`) — `@xenova/transformers` is **mocked** so these run offline and fast, with no model download or inference.
  - `dropDuplicates` (`src/utils/dataLoader.ts`)
- **Live e2e** (`tests/e2e/ingest-retrieve.test.ts`) exercises a real embed → upsert → query round-trip using the same Pinecone primitives `src/index.ts` uses. Key decisions:
  - **Gated + self-skipping** via `describe.skipIf` — with no credentials it skips cleanly, so `npm test` is green locally and on untrusted-PR CI.
  - Creates a **uniquely-named throwaway index** (timestamp-suffixed) so concurrent runs never collide and teardown can't clobber a real index; deletes it in `afterAll` even on assertion failure.
  - **Polls with exponential backoff** for index readiness and for upsert visibility rather than sleeping a fixed interval, to ride out eventual-consistency lag deterministically.

**Scope decision (why the e2e ships dormant):** the shipped code still uses the removed Pinecone v0.1 API and cannot reach a serverless index, so the *credentialed* e2e path can't be validated until #16 modernizes the SDK — which is exactly what #16's acceptance criteria state ("the test suite (#15) is green **after** the upgrade"). So this PR verifies the behavior that is verifiable now (clean self-skip; green unit suite) and writes the e2e against the currently-installed SDK so it compiles; #16 re-points it at serverless and validates it live. The lockfile regeneration is deliberately left to #17 — CI uses `npm install`, which resolves `vitest` without a lockfile bump, keeping this diff minimal.

**CI wiring:** unit tests run on every push + PR in the existing lint/typecheck job; a separate `e2e` job runs the credentialed suite only off untrusted PRs (`if: github.event_name != 'pull_request'`, plus `workflow_dispatch`), so live secrets are never exposed to PR CI.

```bash
npm run test        # unit tests + e2e (e2e self-skips without credentials)
npm run test:unit   # credential-free unit tests only
npm run test:e2e    # live Pinecone round-trip (needs PINECONE_API_KEY, etc.)
```

Verified locally: `lint`, `typecheck`, and `test:unit` all pass; the full `npm test` reports **12 passed, 1 skipped** (the e2e) with no credentials present.

Closes #15
Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)