### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @pinecone-io/dev-advocates @pinecone-io/sdk


### PR DESCRIPTION
Adds a CODEOWNERS file so review requests route to the owning team(s). Opened as part of onboarding `pinecone-io/langchain-retrieval-agent-example` into the groundskeeper maintenance fleet. A human reviews and merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub-only metadata with no code, security, or deployment impact.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file so GitHub automatically requests reviews from **@pinecone-io/dev-advocates** and **@pinecone-io/sdk** for all paths (`*`).
> 
> This is repo governance for onboarding into the groundskeeper maintenance fleet; it does not change application code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b5cd735e0019cd8b34bbbe2b0c2780fc88432c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->