### PR TITLE
security: remediate open Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2582,9 +2582,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3537,9 +3537,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4749,9 +4749,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",
@@ -5053,9 +5053,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5575,9 +5575,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -5595,7 +5595,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

Remediates all 3 open Dependabot alerts by bumping vulnerable transitive
dependencies to their patched versions via `npm audit fix` (no `--force`).
**Lockfile-only change** — `package-lock.json` only, no manifest or source edits.

## Alerts fixed

| Package | Scope | Severity | Alert | Change | Advisory |
|---|---|---|---|---|---|
| js-yaml | runtime | high | #126 | 5.2.1 → 5.2.3 | GHSA-pm4m-ph32-ghv5, GHSA-5p4m-2wfm-xmqj (via `@langchain/classic`) |
| js-yaml | dev | high | #130 | 4.3.0 → 4.3.1 | (via `eslint` / `@eslint/eslintrc`) |
| postcss | dev | medium | #129 | 8.5.20 → 8.5.26 | GHSA-fxqj-rqcc-2cmp |

Same `npm audit fix` pass also cleared two transitive vulns that did not yet
have a distinct open Dependabot alert:

| Package | Change | Advisory |
|---|---|---|
| brace-expansion | 1.1.17 → 1.1.18 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| nanoid | → 3.3.18 | GHSA-2v37-7h3g-55p8 |

All bumps are within existing semver ranges — no major bumps, no breaking changes.

## Deferred

None. All open alerts remediated.

## CI

No changes — `.github/workflows/ci.yml` already covers install + lint + format + typecheck + unit tests (+ gated live e2e).

## Local verification (all pass)

```
npm ci                 # clean install from regenerated lockfile
npm audit              # found 0 vulnerabilities (was 1 moderate, 3 high)
npm run lint           # pass (eslint src)
npm run format:check   # pass (prettier)
npm run typecheck      # pass (tsc --noEmit)
npm run test:unit      # 4 files, 20 tests passed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency lockfile-only security patches within existing semver ranges; no application or API behavior changes.
> 
> **Overview**
> **Lockfile-only** update to `package-lock.json` from `npm audit fix` (no `package.json` or source changes). Patched transitive dependencies stay within existing semver ranges.
> 
> **Security fixes:** `js-yaml` 5.2.1→5.2.3 (runtime, via `@langchain/classic`) and 4.3.0→4.3.1 (dev, via eslint); `postcss` 8.5.20→8.5.26 (dev). Also bumps `brace-expansion` 1.1.16→1.1.18 and `nanoid` 3.3.16→3.3.18. The lockfile drops nested `vite-node` copies of `@types/node` and `undici-types` as part of the resolved tree refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323e6da3c2b209ee391aba05a68b41db717dfce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->