### PR TITLE
ci: add dependency audit + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       # Unit tests are credential-free and run on every push + PR.
       - run: npm run test:unit
 
+      # Fail the build on high/critical dependency vulnerabilities.
+      - run: npm audit --audit-level=high
+
   e2e:
     name: Live e2e (Pinecone)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds the two remaining pieces of the standard CI bar to `langchain-retrieval-agent-example`. Existing CI already runs lint, `prettier` format check, typecheck, and unit tests with fork-safe e2e gating and least-privilege permissions. This adds:

1. **Dependency audit on PRs** — `npm audit --audit-level=high`.
2. **`.github/dependabot.yml`** — weekly npm + github-actions updates (grouped).

## Verification (local, npm 10 — matches CI's Node 22)

- `npm audit --audit-level=high` → **0 vulnerabilities** ✅. No dependency changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub workflow and Dependabot configuration with no application or runtime behavior changes.
> 
> **Overview**
> Extends the existing **CI build job** so PRs and pushes fail when `npm audit` reports **high or critical** vulnerabilities, after the current lint, format, typecheck, and unit-test steps.
> 
> Introduces **Dependabot** via a new `.github/dependabot.yml`: **weekly** updates for root **npm** dependencies (grouped dev minor/patch vs production patch only, cap 10 open PRs) and **GitHub Actions** (cap 5 open PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ad70d59c44ece5e169465c57d97124839c3606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->